### PR TITLE
MCP SDK upgrade, caching, pagination fix, and new ePortfolio/Module tools

### DIFF
--- a/src/canvasClient.ts
+++ b/src/canvasClient.ts
@@ -182,6 +182,21 @@ export class CanvasClient {
   async updateModulePublish(courseId: string, moduleId: string, data: any) {
     return this.put(`/api/v1/courses/${courseId}/modules/${moduleId}`, data);
   }
+  async createModule(courseId: string, data: any) {
+    return this.post(`/api/v1/courses/${courseId}/modules`, data);
+  }
+  async updateModule(courseId: string, moduleId: string, data: any) {
+    return this.put(`/api/v1/courses/${courseId}/modules/${moduleId}`, data);
+  }
+  async getModuleItem(courseId: string, moduleId: string, itemId: string) {
+    return this.get(`/api/v1/courses/${courseId}/modules/${moduleId}/items/${itemId}`);
+  }
+  async createModuleItem(courseId: string, moduleId: string, data: any) {
+    return this.post(`/api/v1/courses/${courseId}/modules/${moduleId}/items`, data);
+  }
+  async updateModuleItem(courseId: string, moduleId: string, itemId: string, data: any) {
+    return this.put(`/api/v1/courses/${courseId}/modules/${moduleId}/items/${itemId}`, data);
+  }
 
   // --- Pages ---
   async listPages(courseId: string, params: any = {}) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { registerSubmissionTools } from './tools/submissions.js';
 import { registerRubricTools } from './tools/rubrics.js';
 import { registerPrompts } from "./tools/prompts.js";
 import { registerQuizTools } from "./tools/quizzes.js";
+import { registerEportfolioTools } from './tools/eportfolios.js';
 // Load environment variables
 dotenv.config();
 
@@ -53,6 +54,7 @@ registerSubmissionTools(server, canvas);
 registerRubricTools(server, canvas);
 registerPrompts(server, canvas);
 registerQuizTools(server, canvas);
+registerEportfolioTools(server, canvas);
 // Start the server
 async function startServer() {
   try {

--- a/src/tools/eportfolios.ts
+++ b/src/tools/eportfolios.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CanvasClient } from "../canvasClient.js";
+
+export function registerEportfolioTools(server: McpServer, canvas: CanvasClient) {
+  // Tool: list-eportfolios
+  server.tool(
+    "list-eportfolios",
+    "List all ePortfolios belonging to a user. Returns id, name, public flag, workflow state, and timestamps.",
+    {
+      userId: z.string().describe("The ID of the user")
+    },
+    { readOnlyHint: true },
+    async ({ userId }: { userId: string }) => {
+      try {
+        const portfolios = await canvas.fetchAllPages<any>(`/api/v1/users/${userId}/eportfolios`);
+        const summary = portfolios.map((p: any) => ({
+          id: p.id,
+          name: p.name,
+          public: p.public,
+          workflow_state: p.workflow_state,
+          created_at: p.created_at,
+          updated_at: p.updated_at,
+        }));
+        return {
+          content: [{ type: "text", text: JSON.stringify(summary) }]
+        };
+      } catch (error: any) {
+        throw new Error(`Failed to fetch ePortfolios: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+  );
+
+  // Tool: get-eportfolio
+  server.tool(
+    "get-eportfolio",
+    "Get details for a single ePortfolio by ID.",
+    {
+      eportfolioId: z.string().describe("The ID of the ePortfolio")
+    },
+    { readOnlyHint: true },
+    async ({ eportfolioId }: { eportfolioId: string }) => {
+      try {
+        const p = await canvas.get<any>(`/api/v1/eportfolios/${eportfolioId}`);
+        const summary = {
+          id: p.id,
+          user_id: p.user_id,
+          name: p.name,
+          public: p.public,
+          workflow_state: p.workflow_state,
+          created_at: p.created_at,
+          updated_at: p.updated_at,
+          spam_status: p.spam_status ?? null,
+        };
+        return {
+          content: [{ type: "text", text: JSON.stringify(summary) }]
+        };
+      } catch (error: any) {
+        throw new Error(`Failed to fetch ePortfolio: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+  );
+
+  // Tool: get-eportfolio-pages
+  server.tool(
+    "get-eportfolio-pages",
+    "List all pages in an ePortfolio. Returns id, position, name, content, and timestamps for each page.",
+    {
+      eportfolioId: z.string().describe("The ID of the ePortfolio")
+    },
+    { readOnlyHint: true },
+    async ({ eportfolioId }: { eportfolioId: string }) => {
+      try {
+        const pages = await canvas.fetchAllPages<any>(`/api/v1/eportfolios/${eportfolioId}/pages`);
+        const summary = pages.map((pg: any) => ({
+          id: pg.id,
+          eportfolio_id: pg.eportfolio_id,
+          position: pg.position,
+          name: pg.name,
+          content: pg.content,
+          created_at: pg.created_at,
+          updated_at: pg.updated_at,
+        }));
+        return {
+          content: [{ type: "text", text: JSON.stringify(summary) }]
+        };
+      } catch (error: any) {
+        throw new Error(`Failed to fetch ePortfolio pages: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+  );
+}

--- a/src/tools/modules.ts
+++ b/src/tools/modules.ts
@@ -122,7 +122,7 @@ export function registerModuleTools(server: McpServer, canvas: CanvasClient) {
       try {
         const current = (await canvas.getModule(courseId, moduleId) as any);
         const newPublished = !current.published;
-        await canvas.updateModulePublish(courseId, moduleId, { published: newPublished });
+        await canvas.updateModulePublish(courseId, moduleId, { module: { published: newPublished } });
         return {
           content: [
             {
@@ -136,6 +136,219 @@ export function registerModuleTools(server: McpServer, canvas: CanvasClient) {
           throw new Error(`Failed to toggle module publish: ${error.message}`);
         }
         throw new Error('Failed to toggle module publish: Unknown error');
+      }
+    }
+  );
+
+  // Tool: create-module
+  server.tool(
+    "create-module",
+    "Create a new module in a course.",
+    {
+      courseId: z.string().describe("The ID of the course"),
+      name: z.string().describe("The name of the module"),
+      position: z.number().optional().describe("Position in the course (1-based)"),
+      unlock_at: z.string().optional().describe("Date the module unlocks (ISO 8601)"),
+      require_sequential_progress: z.boolean().optional().describe("Whether items must be unlocked in order"),
+      prerequisite_module_ids: z.array(z.string()).optional().describe("IDs of modules that must be completed first"),
+      publish_final_grade: z.boolean().optional().describe("Publish student's final grade upon completion")
+    },
+    { destructiveHint: false },
+    async (args: any) => {
+      const { courseId, ...fields } = args;
+      try {
+        const mod = await canvas.createModule(courseId, { module: fields }) as any;
+        return {
+          content: [{ type: "text", text: `Module created: id=${mod.id}, name="${mod.name}", position=${mod.position}, published=${mod.published}` }]
+        };
+      } catch (error: any) {
+        throw new Error(`Failed to create module: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+  );
+
+  // Tool: update-module
+  server.tool(
+    "update-module",
+    "Update an existing module's name, position, prerequisites, sequential progress, or published state.",
+    {
+      courseId: z.string().describe("The ID of the course"),
+      moduleId: z.string().describe("The ID of the module"),
+      name: z.string().optional(),
+      position: z.number().optional(),
+      unlock_at: z.string().optional(),
+      require_sequential_progress: z.boolean().optional(),
+      prerequisite_module_ids: z.array(z.string()).optional(),
+      publish_final_grade: z.boolean().optional(),
+      published: z.boolean().optional()
+    },
+    { idempotentHint: true },
+    async (args: any) => {
+      const { courseId, moduleId, ...fields } = args;
+      try {
+        const mod = await canvas.updateModule(courseId, moduleId, { module: fields }) as any;
+        return {
+          content: [{ type: "text", text: `Module updated: id=${mod.id}, name="${mod.name}", position=${mod.position}, published=${mod.published}` }]
+        };
+      } catch (error: any) {
+        throw new Error(`Failed to update module: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+  );
+
+  // Tool: delete-module
+  server.tool(
+    "delete-module",
+    "Delete a module from a course. This is permanent and removes all module items.",
+    {
+      courseId: z.string().describe("The ID of the course"),
+      moduleId: z.string().describe("The ID of the module")
+    },
+    { destructiveHint: true },
+    async ({ courseId, moduleId }: { courseId: string; moduleId: string }) => {
+      try {
+        await canvas.delete(`/api/v1/courses/${courseId}/modules/${moduleId}`);
+        return {
+          content: [{ type: "text", text: `Module ${moduleId} deleted from course ${courseId}.` }]
+        };
+      } catch (error: any) {
+        throw new Error(`Failed to delete module: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+  );
+
+  // Tool: get-module-item
+  server.tool(
+    "get-module-item",
+    "Get details for a single module item.",
+    {
+      courseId: z.string().describe("The ID of the course"),
+      moduleId: z.string().describe("The ID of the module"),
+      itemId: z.string().describe("The ID of the module item")
+    },
+    { readOnlyHint: true },
+    async ({ courseId, moduleId, itemId }: { courseId: string; moduleId: string; itemId: string }) => {
+      try {
+        const item = await canvas.getModuleItem(courseId, moduleId, itemId) as any;
+        const summary = {
+          id: item.id,
+          module_id: item.module_id,
+          position: item.position,
+          title: item.title,
+          type: item.type,
+          content_id: item.content_id,
+          published: item.published,
+          indent: item.indent,
+          external_url: item.external_url,
+          page_url: item.page_url,
+          completion_requirement: item.completion_requirement ?? null,
+        };
+        return {
+          content: [{ type: "text", text: JSON.stringify(summary) }]
+        };
+      } catch (error: any) {
+        throw new Error(`Failed to fetch module item: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+  );
+
+  // Tool: create-module-item
+  server.tool(
+    "create-module-item",
+    "Add a new item to a module. Type must be one of: File, Page, Discussion, Assignment, Quiz, SubHeader, ExternalUrl, ExternalTool.",
+    {
+      courseId: z.string().describe("The ID of the course"),
+      moduleId: z.string().describe("The ID of the module"),
+      type: z.enum(['File', 'Page', 'Discussion', 'Assignment', 'Quiz', 'SubHeader', 'ExternalUrl', 'ExternalTool']).describe("The type of content to link"),
+      content_id: z.string().optional().describe("ID of the content to link (required except for ExternalUrl, Page, SubHeader)"),
+      title: z.string().optional().describe("Title of the item"),
+      position: z.number().optional().describe("Position in the module (1-based)"),
+      indent: z.number().optional().describe("Indent level (0-based)"),
+      page_url: z.string().optional().describe("Page URL slug (required for Page type)"),
+      external_url: z.string().optional().describe("External URL (required for ExternalUrl and ExternalTool types)"),
+      new_tab: z.boolean().optional().describe("Whether ExternalTool opens in a new tab"),
+      completion_requirement_type: z.enum(['must_view', 'must_contribute', 'must_submit', 'must_mark_done']).optional().describe("Completion requirement type"),
+      completion_requirement_min_score: z.number().optional().describe("Minimum score for must_submit completion requirement")
+    },
+    { destructiveHint: false },
+    async (args: any) => {
+      const { courseId, moduleId, completion_requirement_type, completion_requirement_min_score, ...rest } = args;
+      const moduleItem: any = { ...rest };
+      if (completion_requirement_type) {
+        moduleItem.completion_requirement = { type: completion_requirement_type };
+        if (completion_requirement_min_score !== undefined) {
+          moduleItem.completion_requirement.min_score = completion_requirement_min_score;
+        }
+      }
+      try {
+        const item = await canvas.createModuleItem(courseId, moduleId, { module_item: moduleItem }) as any;
+        return {
+          content: [{ type: "text", text: `Module item created: id=${item.id}, type=${item.type}, title="${item.title}", position=${item.position}` }]
+        };
+      } catch (error: any) {
+        throw new Error(`Failed to create module item: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+  );
+
+  // Tool: update-module-item
+  server.tool(
+    "update-module-item",
+    "Update an existing module item's title, position, indent, external URL, published state, completion requirement, or move it to another module.",
+    {
+      courseId: z.string().describe("The ID of the course"),
+      moduleId: z.string().describe("The ID of the module"),
+      itemId: z.string().describe("The ID of the module item"),
+      title: z.string().optional(),
+      position: z.number().optional(),
+      indent: z.number().optional(),
+      external_url: z.string().optional(),
+      new_tab: z.boolean().optional(),
+      published: z.boolean().optional(),
+      move_to_module_id: z.string().optional().describe("Move this item to a different module"),
+      completion_requirement_type: z.enum(['must_view', 'must_contribute', 'must_submit', 'must_mark_done']).optional(),
+      completion_requirement_min_score: z.number().optional()
+    },
+    { idempotentHint: true },
+    async (args: any) => {
+      const { courseId, moduleId, itemId, completion_requirement_type, completion_requirement_min_score, move_to_module_id, ...rest } = args;
+      const moduleItem: any = { ...rest };
+      if (move_to_module_id) moduleItem.module_id = move_to_module_id;
+      if (completion_requirement_type) {
+        moduleItem.completion_requirement = { type: completion_requirement_type };
+        if (completion_requirement_min_score !== undefined) {
+          moduleItem.completion_requirement.min_score = completion_requirement_min_score;
+        }
+      }
+      try {
+        const item = await canvas.updateModuleItem(courseId, moduleId, itemId, { module_item: moduleItem }) as any;
+        return {
+          content: [{ type: "text", text: `Module item updated: id=${item.id}, type=${item.type}, title="${item.title}", position=${item.position}, published=${item.published}` }]
+        };
+      } catch (error: any) {
+        throw new Error(`Failed to update module item: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+  );
+
+  // Tool: delete-module-item
+  server.tool(
+    "delete-module-item",
+    "Remove an item from a module.",
+    {
+      courseId: z.string().describe("The ID of the course"),
+      moduleId: z.string().describe("The ID of the module"),
+      itemId: z.string().describe("The ID of the module item")
+    },
+    { destructiveHint: true },
+    async ({ courseId, moduleId, itemId }: { courseId: string; moduleId: string; itemId: string }) => {
+      try {
+        await canvas.delete(`/api/v1/courses/${courseId}/modules/${moduleId}/items/${itemId}`);
+        return {
+          content: [{ type: "text", text: `Module item ${itemId} deleted from module ${moduleId}.` }]
+        };
+      } catch (error: any) {
+        throw new Error(`Failed to delete module item: ${error instanceof Error ? error.message : 'Unknown error'}`);
       }
     }
   );


### PR DESCRIPTION
## Summary

- **MCP SDK upgraded** to 1.29.0 — uses `McpServer` type and 5-argument `server.tool()` with `ToolAnnotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`)
- **Token reduction** — field-filtered responses across all tools so the LLM only receives relevant fields instead of full Canvas API payloads
- **ETag-based caching** — `GET` requests send `If-None-Match`/`If-Modified-Since`; a `304 Not Modified` returns no body, saving tokens on repeated reads. TTL fallback (30 min) for endpoints without validators. Submission/grade endpoints are never cached.
- **Pagination fix** (fixes #1) — submission, student, and rubric assessment list endpoints now use `fetchAllPages` (Link-header pagination) instead of a single `GET`, so large classes return all results instead of just 10
- **New ePortfolio tools** (read-only — portfolios belong to students): `list-eportfolios`, `get-eportfolio`, `get-eportfolio-pages`
- **New Module tools** (full CRUD): `create-module`, `update-module`, `delete-module`, `get-module-item`, `create-module-item`, `update-module-item`, `delete-module-item`
- **Bug fix** — `toggle-module-publish` now correctly wraps the PUT body in `{ module: { published: ... } }` per Canvas API spec

## Test plan

- [ ] Build passes (`npm run build`) with no TypeScript errors
- [ ] Existing tools (courses, assignments, rubrics, submissions, pages) still return correct field-filtered responses
- [ ] Submitting a large course (`>10 students`) now returns all students and all submissions
- [ ] `list-eportfolios` returns portfolios for a given user ID
- [ ] `list-modules` with `includeItems: true` returns modules with inline items
- [ ] `create-module` / `update-module` / `delete-module` round-trip correctly
- [ ] `toggle-module-publish` flips published state correctly (previously broken)
- [ ] Repeated `GET` requests hit the ETag cache and return `304` responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019swyfVa1VL6p8gKUkqwFXk

---
_Generated by [Claude Code](https://claude.ai/code/session_019swyfVa1VL6p8gKUkqwFXk)_