### PR TITLE
Restructure README and sync project metadata

### DIFF
--- a/DESKTOP_EXTENSION.md
+++ b/DESKTOP_EXTENSION.md
@@ -169,7 +169,7 @@ To submit to the official Claude Desktop Extension directory:
 
 ### Getting Help
 
-- Check the [issues page](https://github.com/your-org/canvas-mcp/issues)
+- Check the [issues page](https://github.com/r-huijts/canvas-mcp/issues)
 - Review Canvas API documentation
 - Contact support via the repository
 

--- a/README.md
+++ b/README.md
@@ -1,152 +1,84 @@
 # Canvas MCP Server
 
-A Model Context Protocol (MCP) server that enables AI assistants like Claude to interact with Canvas LMS. This server provides tools for managing courses, announcements, rubrics, assignments, modules, pages, and student data through the Canvas API.
+[![npm version](https://img.shields.io/npm/v/@r-huijts/canvas-mcp)](https://www.npmjs.com/package/@r-huijts/canvas-mcp)
+[![license](https://img.shields.io/npm/l/@r-huijts/canvas-mcp)](LICENSE)
+[![MCP](https://img.shields.io/badge/MCP-stdio-blue)](https://modelcontextprotocol.io)
 
-**🚀 Now available as a Claude Desktop Extension for one-click installation!**
+> Connect AI assistants to Canvas LMS — manage courses, grade submissions, edit pages, and analyze rubrics through natural conversation.
+
+## Quick Start
+
+1. **Get a Canvas API token** — Canvas → Account → Settings → Approved Integrations → [New Access Token](https://community.canvaslms.com/t5/Student-Guide/How-do-I-manage-API-access-tokens-as-a-student/ta-p/273)
+2. **Install** via [Claude Desktop Extension](#option-1-desktop-extension-easiest) or `npx @r-huijts/canvas-mcp`
+3. **Try a prompt** — *"List all my active Canvas courses"*
+
+## Table of Contents
+
+- [Features](#features)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Claude Desktop Integration](#claude-desktop-integration)
+- [Other MCP Clients](#other-mcp-clients)
+- [Usage Examples](#usage-examples)
+- [Student Data Privacy](#student-data-privacy)
+- [Tool Reference](#tool-reference)
+- [Available Prompts](#available-prompts)
+- [Troubleshooting](#troubleshooting)
+- [Performance & Caching](#performance--caching)
+- [Development](#development)
+- [Contributing](#contributing)
+- [Security Notes](#security-notes)
+- [Related Documentation](#related-documentation)
+- [License](#license)
 
 ## Features
 
-- List active courses and their details
-- Post announcements to courses
-- View, create, update, and delete assignments and assignment groups
-- Grade submissions and post feedback comments
-- View course rubrics and rubric assessment statistics
-- Attach rubrics to assignments
-- Get student enrollment information
-- Access assignment details and submissions, including file downloads
-- View student submission history and comments
-- **Manage course modules and module items**
-- **Manage course pages, including content, revisions, and rollbacks**
-- **Manage quizzes, including questions and question groups**
-- **ETag-based response caching** — unchanged data is never re-fetched, reducing API load and token use
+- **Courses** — list active courses, post announcements
+- **Assignments** — create, update, delete assignments and assignment groups; bulk date updates
+- **Submissions** — grade work, post feedback, download submission files
+- **Rubrics** — view rubrics, analyze statistics, attach rubrics to assignments
+- **Students** — enrollment lists with privacy-first anonymization
+- **Sections** — list sections and section-filtered submissions
+- **Modules** — full module and module-item CRUD
+- **Pages** — edit content, manage revisions, and use the styleguide system (`generate-styleguide`, `patch-page-content`)
+- **Quizzes** — full quiz, question, and question-group CRUD
+- **ePortfolios** — list and read student ePortfolios
+- **Prompts** — `analyze-rubric-statistics` for multi-assignment rubric visualizations
+- **Performance** — ETag-based response caching to reduce API load and token use
 
-## Desktop Extension Benefits 🎯
-
-The Canvas MCP server is now available as a **Claude Desktop Extension** for the ultimate user experience:
-
-- **🎯 One-Click Installation**: No terminal commands, no manual configuration
-- **🔒 Secure Configuration**: API tokens stored securely in your OS keychain
-- **🔄 Automatic Updates**: Get new features and fixes automatically
-- **📦 Zero Dependencies**: Everything bundled - no Node.js installation required
-- **🌍 Cross-Platform**: Works seamlessly on macOS and Windows
-- **🎨 Native UI**: Configure settings through Claude Desktop's beautiful interface
-
-Perfect for educators who want powerful Canvas integration without the technical complexity!
-
-## Student Data Privacy & Anonymization 🔒
-
-This Canvas MCP server includes **privacy-first anonymization** for student data. By default, all student names and emails are anonymized to protect privacy, but you can request real data when needed using natural language.
-
-### How It Works
-
-**Default Behavior (Anonymous):**
-- Student names become: `Student 1`, `Student 2`, etc.
-- Student emails become: `student1@example.com`, `student2@example.com`
-- Same student always gets the same pseudonym across all API calls
-- Teacher/admin names are **never anonymized** (preserved in comments)
-
-**Natural Language Control:**
-You can easily switch to real data by asking for it naturally:
-
-```
-❌ Anonymous (default):
-"List all students in course 123"
-→ Returns: Student 1, Student 2, student1@example.com
-
-✅ Non-anonymous:
-"List all students in course 123, but show their actual names and emails"
-"Get assignment submissions with real student names"  
-"Show me student data with actual identities"
-→ Returns: John Smith, Jane Doe, john.smith@university.edu
-```
-
-### Affected Tools
-
-The following tools support anonymization control:
-- `list-students` - Student enrollment data
-- `list-assignments` - When including student submission data  
-- `list-assignment-submissions` - All submission data
-- `list-section-submissions` - Section-filtered submissions
-- `list-rubric-assessments` - Rubric assessment data
-
-### Privacy Features
-
-🔒 **Privacy by Default**: All student data is anonymized unless explicitly requested otherwise  
-🗣️ **Natural Language**: Just ask for "actual names" when you need them  
-👨‍🏫 **Teacher Protection**: Teacher/admin names are never anonymized  
-🔄 **Consistent Mapping**: Same student gets same pseudonym across all calls  
-🎯 **Selective**: Only anonymizes student data, preserves all other information  
-
-### Why Teachers/Admins Aren't Anonymized
-
-The anonymization system specifically targets **student privacy** while preserving educational context:
-
-**🎓 Educational Rationale:**
-- **Students are the protected population** - They're the vulnerable party whose privacy needs protection
-- **Teacher feedback context matters** - Knowing which instructor provided feedback is pedagogically valuable
-- **Staff accountability** - Teachers and admins are professional staff, not students requiring privacy protection
-
-**📝 Practical Examples:**
-```
-Assignment Comments (with anonymization enabled):
-✅ "Excellent analysis of the data trends! - Prof. Johnson"
-❌ "I found this section confusing - Student 1" 
-❌ "Thanks for the feedback! - Student 2"
-```
-
-**🔍 Technical Implementation:**
-- Comments include an `author.role` field (`'student'`, `'teacher'`, `'admin'`, `'ta'`)
-- Only authors with `role === 'student'` get anonymized
-- Staff roles preserve real names for educational context
-
-This design ensures student privacy while maintaining the educational value of knowing which instructor provided specific feedback. If you need full anonymization including staff, you can modify the anonymizer logic or request this as a feature enhancement.
-
-### Technical Implementation
-
-Each tool that handles student data includes an `anonymous` parameter:
-- **Default**: `anonymous: true` (privacy-first)
-- **Override**: Claude automatically sets `anonymous: false` when you request real names
-- **Preserved**: All functional IDs and non-personal data remain unchanged
-
-Example of how Claude interprets your requests:
-- "with their actual names" → `anonymous: false`
-- "show real emails" → `anonymous: false`  
-- "anonymized" → `anonymous: true` (default anyway)
-- "hide student identities" → `anonymous: true`
+**60 tools** and **1 prompt** in total. See [docs/TOOLS.md](docs/TOOLS.md) for the full parameter reference.
 
 ## Prerequisites
 
-- Node.js (v16 or higher)
-- A Canvas API token
-- Canvas instance URL (defaults to "https://fhict.instructure.com")
+- Node.js v16 or higher (for npm/source installs; not required for the Desktop Extension)
+- A Canvas API token with access to the courses you intend to manage
+- Your Canvas instance URL (e.g. `https://yourschool.instructure.com`)
+
+> **Note:** The server defaults to `https://fhict.instructure.com` if `CANVAS_BASE_URL` is not set. Set this variable to your own institution's Canvas URL.
 
 ## Installation
 
-### Option 1: Desktop Extension (Easiest) 🚀
+### Option 1: Desktop Extension (Easiest)
 
-**NEW!** One-click installation with Claude Desktop Extensions:
+One-click installation with Claude Desktop Extensions:
 
-1. **Download** the latest extension: [canvas-mcp-1.0.8.mcpb](https://github.com/r-huijts/canvas-mcp/releases/latest)
-2. **Double-click** the `.mcpb` file to open with Claude Desktop
-3. **Click "Install"** - that's it!
+1. **Download** the latest extension from [GitHub Releases](https://github.com/r-huijts/canvas-mcp/releases) (`.mcpb` or `.dxt` format, depending on the release)
+2. **Open** the file with Claude Desktop (double-click or drag-and-drop)
+3. **Click "Install"**
 4. **Configure** your Canvas API token and base URL through the Claude Desktop UI
 
-**Benefits:**
-- ✅ **One-click installation** - no terminal required
-- ✅ **Automatic updates** when new versions are available
-- ✅ **Secure configuration** - API tokens stored in OS keychain
-- ✅ **No dependencies** - everything bundled in the extension
-- ✅ **Cross-platform** - works on macOS and Windows
+Benefits: no terminal required, secure token storage in the OS keychain, bundled dependencies, cross-platform (macOS and Windows).
+
+To build the extension yourself, see [DESKTOP_EXTENSION.md](DESKTOP_EXTENSION.md).
 
 ### Option 2: NPM Package (Recommended)
-
-The easiest way to use this MCP server is via npm:
 
 ```bash
 npm install -g @r-huijts/canvas-mcp
 ```
 
-Or use directly with npx (no installation required):
+Or run directly without installing:
 
 ```bash
 npx @r-huijts/canvas-mcp
@@ -154,55 +86,64 @@ npx @r-huijts/canvas-mcp
 
 ### Option 3: From Source
 
-1. Clone this repository and install dependencies:
-   ```bash
-   git clone <repository-url>
-   cd canvas-mcp
-   npm install
-   ```
+```bash
+git clone https://github.com/r-huijts/canvas-mcp
+cd canvas-mcp
+npm install
+cp .env.example .env   # then edit with your credentials
+npm run build
+npm start
+```
 
-2. Create a `.env` file in the project root:
-   ```
-   CANVAS_API_TOKEN=your_canvas_api_token_here
-   CANVAS_BASE_URL=https://your-canvas-instance.instructure.com
-   ```
+For development with auto-reload:
 
-3. Build the TypeScript project:
-   ```bash
-   npm run build
-   ```
+```bash
+npm run dev
+```
 
-4. Start the server:
-   ```bash
-   npm start
-   ```
+## Configuration
+
+Set these environment variables (via `.env` file, MCP client config, or shell):
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `CANVAS_API_TOKEN` | Yes | Personal access token from Canvas |
+| `CANVAS_BASE_URL` | No | Your Canvas instance URL (default: `https://fhict.instructure.com`) |
+
+See [.env.example](.env.example) for a template.
+
+### Getting a Canvas API Token
+
+1. Log in to your Canvas instance
+2. Go to **Account → Settings → Approved Integrations**
+3. Click **+ New Access Token**
+4. Copy the token — you won't be able to see it again
+
+Your token must belong to a user with teacher (or equivalent) access to the courses you want to manage. Canvas personal access tokens inherit the permissions of the account that created them.
 
 ## Claude Desktop Integration
 
 1. Open Claude Desktop's configuration file:
 
-   **MacOS**:
+   **macOS:**
    ```bash
    code ~/Library/Application\ Support/Claude/claude_desktop_config.json
    ```
 
-   **Windows**:
+   **Windows:**
    ```bash
    code %AppData%\Claude\claude_desktop_config.json
    ```
 
-2. Add the Canvas MCP server configuration:
+2. Add the Canvas MCP server:
 
-   ### For NPM Package Installation (Recommended):
+   **NPM package (recommended):**
    ```json
    {
      "mcpServers": {
        "canvas": {
          "command": "npx",
-         "args": [
-           "-y",
-           "@r-huijts/canvas-mcp"
-         ],
+         "args": ["-y", "@r-huijts/canvas-mcp"],
          "env": {
            "CANVAS_API_TOKEN": "your_token_here",
            "CANVAS_BASE_URL": "https://your-canvas-instance.com"
@@ -212,15 +153,13 @@ npx @r-huijts/canvas-mcp
    }
    ```
 
-   ### For Source Installation:
+   **From source:**
    ```json
    {
      "mcpServers": {
        "canvas": {
          "command": "node",
-         "args": [
-           "/path/to/canvas-mcp/build/index.js"
-         ],
+         "args": ["/absolute/path/to/canvas-mcp/dist/index.js"],
          "env": {
            "CANVAS_API_TOKEN": "your_token_here",
            "CANVAS_BASE_URL": "https://your-canvas-instance.com"
@@ -230,559 +169,188 @@ npx @r-huijts/canvas-mcp
    }
    ```
 
-3. Restart Claude Desktop to apply changes
-
-### Installation Notes
-
-**Benefits of NPM Package Installation:**
-- ✅ No need to clone/build source code
-- ✅ Automatic updates available via npm
-- ✅ Simpler configuration
-- ✅ Works across different operating systems
-- ✅ The `-y` flag automatically accepts package installation prompts
-
-**Troubleshooting NPX Issues:**
-- If you encounter permission issues, try running Claude Desktop as administrator (Windows) or with sudo (macOS)
-- On Windows, ensure your PATH includes npm/npx executables
-- For corporate networks, you may need to configure npm proxy settings
-
-## Available Tools
-
-### list-courses
-Lists all active courses for the authenticated user
-- No required parameters
-- Returns course names, IDs, and term information
-
-### post-announcement
-Posts an announcement to a specific course
-- Required parameters:
-  - courseId: string
-  - title: string
-  - message: string
-
-### list-rubrics
-Lists all rubrics for a specific course
-- Required parameters:
-  - courseId: string
-- Returns rubric titles, IDs, and descriptions
-
-### get-rubric-statistics
-Gets statistics for rubric assessments on an assignment
-- Required parameters:
-  - courseId: string
-  - assignmentId: string
-- Optional parameters:
-  - includePointDistribution: boolean (default: true)
-- Returns overall and per-criterion statistics including average, median, min, max, and score distribution
-
-### list-rubric-assessments
-Lists all rubric assessments for an assignment
-- Required parameters:
-  - courseId: string
-  - assignmentId: string
-- Optional parameters:
-  - anonymous: boolean (default: true)
-- Returns per-submission rubric scores and criteria ratings
-
-### attach-rubric-to-assignment
-Attaches an existing rubric to an assignment
-- Required parameters:
-  - courseId: string
-  - assignmentId: string
-  - rubricId: string
-
-### list-students
-Gets a complete list of students enrolled in a course
-- Required parameters:
-  - courseId: string
-- Optional parameters:
-  - includeEmail: boolean (default: false)
-  - anonymous: boolean (default: true) - Whether to anonymize student names/emails
-- Returns student names, IDs, and optional email addresses
-- **Privacy**: Student data is anonymized by default (use "with actual names" to override)
-
-### list-assignments
-Gets all assignments in a course with submission status
-- Required parameters:
-  - courseId: string
-- Optional parameters:
-  - studentId: string
-  - includeSubmissionHistory: boolean (default: false)
-  - anonymous: boolean (default: true) - Whether to anonymize student data in submissions
-- Returns assignment details and submission status
-- **Privacy**: Student submission data is anonymized by default
-
-### get-assignment
-Fetches metadata for a single assignment
-- Required parameters:
-  - courseId: string
-  - assignmentId: string
-- Returns due date, points, grading type, submission types, rubric presence, and publish state
-
-### create-assignment
-Creates a new assignment in a course
-- Required parameters:
-  - courseId: string
-- Optional parameters:
-  - name, description, due_at, points_possible, submission_types, published, grading_type, assignment_group_id
-
-### update-assignment
-Updates an existing assignment
-- Required parameters:
-  - courseId: string
-  - assignmentId: string
-- Optional parameters: same as create-assignment
-
-### delete-assignment
-Deletes (archives) an assignment from a course
-- Required parameters:
-  - courseId: string
-  - assignmentId: string
-
-### list-assignment-groups
-Lists all assignment groups (grade buckets) in a course
-- Required parameters:
-  - courseId: string
-- Returns group name, ID, position, weight, and drop rules
-
-### create-assignment-group
-Creates a new assignment group in a course
-- Required parameters:
-  - courseId: string
-- Optional parameters:
-  - name, position, group_weight, sis_source_id, rules
-
-### bulk-update-assignment-dates
-Updates due/unlock/lock dates for multiple assignments in one call
-- Required parameters:
-  - courseId: string
-  - assignmentDates: array of `{ assignment_id, due_at?, unlock_at?, lock_at? }`
-
-### grade-submission
-Writes a score, grade, rubric assessment, or comment for a student's submission
-- Required parameters:
-  - courseId: string
-  - assignmentId: string
-  - userId: string
-- Optional parameters:
-  - posted_grade, score, rubric_assessment, comment
-
-### list-assignment-submissions
-Gets all student submissions for a specific assignment
-- Required parameters:
-  - courseId: string
-  - assignmentId: string
-- Optional parameters:
-  - anonymous: boolean (default: true) - Whether to anonymize student names/emails
-- Returns submission details, grades, and comments
-- **Privacy**: Student data is anonymized by default
-
-### get-submission-documents
-Retrieves a student's submission with attachment metadata and optional file content
-- Required parameters:
-  - courseId: string
-  - assignmentId: string
-  - userId: string
-- Optional parameters:
-  - downloadFiles: boolean (default: false)
-  - anonymous: boolean (default: true)
-
-### get-submission-file-info
-Returns metadata for a specific file attached to a submission
-- Required parameters:
-  - fileId: string
-
-### download-submission-file
-Downloads a submission file as text or base64
-- Required parameters:
-  - fileId: string
-- Optional parameters:
-  - forceBase64: boolean (default: false)
-
-### list-section-submissions
-Gets all student submissions for a specific assignment filtered by section
-- Required parameters:
-  - courseId: string
-  - assignmentId: string
-  - sectionId: string
-- Optional parameters:
-  - includeComments: boolean (default: true)
-  - anonymous: boolean (default: true) - Whether to anonymize student names/emails
-- Returns submission details filtered by the specified section
-- **Privacy**: Student data is anonymized by default
-
-### list-sections
-Gets a list of all sections in a course
-- Required parameters:
-  - courseId: string
-- Optional parameters:
-  - includeStudentCount: boolean (default: false)
-- Returns section details with optional student count
-
-### post-submission-comment
-Posts a comment on a student's assignment submission
-- Required parameters:
-  - courseId: string
-  - assignmentId: string
-  - studentId: string
-  - comment: string
-- Returns confirmation of the posted comment
-
-### list-modules
-Lists all modules in a course, optionally including inline items
-- Required parameters:
-  - courseId: string
-- Optional parameters:
-  - includeItems: boolean (default: false)
-- Returns module names, IDs, positions, published state, and optionally item summaries
-
-### list-module-items
-Lists all items in a specific module
-- Required parameters:
-  - courseId: string
-  - moduleId: string
-- Returns item type, title, ID, position, and published state
-
-### toggle-module-publish
-Toggles the published/unpublished state of a module
-- Required parameters:
-  - courseId: string
-  - moduleId: string
-- Returns confirmation of the new published state
-
-### create-module
-Creates a new module in a course
-- Required parameters:
-  - courseId: string
-  - name: string
-- Optional parameters:
-  - position: number (1-based)
-  - unlock_at: string (ISO 8601 date)
-  - require_sequential_progress: boolean
-  - prerequisite_module_ids: string[]
-  - publish_final_grade: boolean
-- Returns the created module's ID, name, position, and published state
-
-### update-module
-Updates an existing module's properties
-- Required parameters:
-  - courseId: string
-  - moduleId: string
-- Optional parameters:
-  - name, position, unlock_at, require_sequential_progress, prerequisite_module_ids, publish_final_grade, published
-- Returns the updated module's ID, name, position, and published state
-
-### delete-module
-Permanently deletes a module and all its items from a course
-- Required parameters:
-  - courseId: string
-  - moduleId: string
-- Returns confirmation of deletion
-
-### get-module-item
-Gets details for a single module item
-- Required parameters:
-  - courseId: string
-  - moduleId: string
-  - itemId: string
-- Returns item ID, type, title, position, content_id, published state, indent, external_url, page_url, and completion requirement
-
-### create-module-item
-Adds a new item to a module
-- Required parameters:
-  - courseId: string
-  - moduleId: string
-  - type: one of File, Page, Discussion, Assignment, Quiz, SubHeader, ExternalUrl, ExternalTool
-- Optional parameters:
-  - content_id, title, position, indent, page_url, external_url, new_tab
-  - completion_requirement_type: must_view | must_contribute | must_submit | must_mark_done
-  - completion_requirement_min_score: number
-- Returns the created item's ID, type, title, and position
-
-### update-module-item
-Updates an existing module item
-- Required parameters:
-  - courseId: string
-  - moduleId: string
-  - itemId: string
-- Optional parameters:
-  - title, position, indent, external_url, new_tab, published
-  - move_to_module_id: string (moves the item to a different module)
-  - completion_requirement_type, completion_requirement_min_score
-- Returns the updated item's ID, type, title, position, and published state
-
-### delete-module-item
-Removes an item from a module
-- Required parameters:
-  - courseId: string
-  - moduleId: string
-  - itemId: string
-- Returns confirmation of deletion
-
-### list-eportfolios
-Lists all ePortfolios belonging to a user
-- Required parameters:
-  - userId: string
-- Returns ePortfolio ID, name, public flag, workflow state, and timestamps
-
-### get-eportfolio
-Gets details for a single ePortfolio
-- Required parameters:
-  - eportfolioId: string
-- Returns ID, user_id, name, public flag, workflow state, spam status, and timestamps
-
-### get-eportfolio-pages
-Lists all pages in an ePortfolio
-- Required parameters:
-  - eportfolioId: string
-- Returns page ID, eportfolio_id, position, name, content, and timestamps
-
-### list-pages
-Lists all pages in a course by URL slug
-- Required parameters:
-  - courseId: string
-- Returns page titles, URL slugs, IDs, and published state
-
-### get-page-content
-Gets the content (HTML/body) of a specific page by URL slug
-- Required parameters:
-  - courseId: string
-  - pageUrl: string (the page's URL slug, e.g. 'syllabus')
-- Returns page title, slug, ID, published state, updated date, and HTML body
-
-### update-page-content
-Updates (or creates) a page by URL slug
-- Required parameters:
-  - courseId: string
-  - pageUrl: string
-- Optional parameters:
-  - title: string
-  - body: string (HTML)
-  - editingRoles: string (comma-separated roles)
-- Returns confirmation and updated page info
-
-### list-page-revisions
-Lists all revisions for a page
-- Required parameters:
-  - courseId: string
-  - pageUrl: string
-- Returns revision IDs, timestamps, and editor info
-
-### revert-page-revision
-Reverts a page to a previous revision
-- Required parameters:
-  - courseId: string
-  - pageUrl: string
-  - revisionId: string
-- Returns confirmation and new page state
-
-### patch-page-content
-Applies targeted edits to a page using find-and-replace or section-level instructions
-- Required parameters:
-  - courseId: string
-  - pageUrl: string
-  - instructions: string
-- Returns the updated page body
-
-### apply-page-changes
-Applies a set of structured diffs to a page (bulk patch)
-- Required parameters:
-  - courseId: string
-  - pageUrl: string
-  - changes: array of `{ find, replace }` pairs
-
-### generate-styleguide
-Generates a course styleguide page from existing page content
-- Required parameters:
-  - courseId: string
-- Analyses existing pages and writes a `styleguide` page capturing fonts, colours, and layout conventions
-
-### get-styleguide
-Retrieves the styleguide page for a course
-- Required parameters:
-  - courseId: string
-
-### Quizzes
-
-#### list-quizzes
-Lists all quizzes in a course
-- Required parameters:
-  - courseId: string
-- Returns a list of quizzes with their details
-
-#### get-quiz
-Fetches metadata for a single quiz
-- Required parameters:
-  - courseId: string
-  - quizId: string
-- Returns the full quiz object
-
-#### create-quiz
-Creates a new quiz in a course
-- Required parameters:
-  - courseId: string
-  - title: string
-- Optional parameters:
-  - description: string
-  - quiz_type: "practice_quiz" | "assignment" | "graded_survey" | "survey"
-  - due_at: string (ISO 8601 format)
-  - points_possible: number
-  - published: boolean
-- Returns the newly created quiz object
-
-#### update-quiz
-Updates an existing quiz
-- Required parameters:
-  - courseId: string
-  - quizId: string
-- Optional parameters: same as create-quiz
-- Returns the updated quiz object
-
-#### delete-quiz
-Deletes a quiz
-- Required parameters:
-  - courseId: string
-  - quizId: string
-- Returns confirmation of deletion
-
-#### list-quiz-questions
-Lists all questions for a quiz
-- Required parameters:
-  - courseId: string
-  - quizId: string
-- Returns a list of question objects
-
-#### get-quiz-question
-Fetches a single quiz question
-- Required parameters:
-  - courseId: string
-  - quizId: string
-  - questionId: string
-- Returns the full question object
-
-#### create-quiz-question
-Creates a new question for a quiz
-- Required parameters:
-  - courseId: string
-  - quizId: string
-  - question: object (containing question_text, question_type, points_possible, etc.)
-- Returns the newly created question object
-
-#### update-quiz-question
-Updates a quiz question
-- Required parameters:
-  - courseId: string
-  - quizId: string
-  - questionId: string
-- Optional parameters:
-  - question: object (with fields to update)
-- Returns the updated question object
-
-#### delete-quiz-question
-Deletes a quiz question
-- Required parameters:
-  - courseId: string
-  - quizId: string
-  - questionId: string
-- Returns confirmation of deletion
-
-#### list-quiz-question-groups
-Lists all question groups for a quiz
-- Required parameters:
-  - courseId: string
-  - quizId: string
-- Returns a list of question group objects
-
-#### get-quiz-question-group
-Fetches a single quiz question group
-- Required parameters:
-  - courseId: string
-  - quizId: string
-  - groupId: string
-- Returns the full question group object
-
-#### create-quiz-question-group
-Creates a new question group for a quiz
-- Required parameters:
-  - courseId: string
-  - quizId: string
-  - quizGroup: object (containing name, pick_count, question_points)
-- Returns the newly created question group object
-
-#### update-quiz-question-group
-Updates a quiz question group
-- Required parameters:
-  - courseId: string
-  - quizId: string
-  - groupId: string
-- Optional parameters:
-  - quizGroup: object (with fields to update)
-- Returns the updated question group object
-
-#### delete-quiz-question-group
-Deletes a quiz question group
-- Required parameters:
-  - courseId: string
-  - quizId: string
-  - groupId: string
-- Returns confirmation of deletion
+3. Restart Claude Desktop
+
+The `-y` flag tells npx to accept the package installation prompt automatically.
+
+## Other MCP Clients
+
+Any MCP client that supports stdio transport can use the same configuration pattern. Replace the config file path with your client's equivalent:
+
+```json
+{
+  "mcpServers": {
+    "canvas": {
+      "command": "npx",
+      "args": ["-y", "@r-huijts/canvas-mcp"],
+      "env": {
+        "CANVAS_API_TOKEN": "your_token_here",
+        "CANVAS_BASE_URL": "https://your-canvas-instance.com"
+      }
+    }
+  }
+}
+```
+
+This works with [Cursor](https://docs.cursor.com/context/mcp), VS Code MCP extensions, and other stdio-based clients. Consult your client's MCP documentation for where to place the config file.
+
+## Usage Examples
+
+Copy-paste these prompts into your AI assistant after connecting the server:
+
+```
+List all my active Canvas courses
+```
+
+```
+Post an announcement to course 12345 titled "Week 3 Update" with a summary of this week's topics
+```
+
+```
+Show rubric statistics for assignment 67890 in course 12345
+```
+
+```
+Generate a styleguide for course 12345, then patch the syllabus page to match it
+```
+
+```
+List all students in course 12345 with their actual names and emails
+```
+
+## Student Data Privacy
+
+This server includes **privacy-first anonymization** for student data. By default, student names and emails are pseudonymized; you can request real identities using natural language.
+
+**Default behavior:**
+- Names become `Student 1`, `Student 2`, etc.
+- Emails become `student1@example.com`, `student2@example.com`
+- The same student always gets the same pseudonym across calls
+- Teacher and admin names are never anonymized
+
+**Requesting real data:**
+```
+List all students in course 123, but show their actual names and emails
+```
+
+**Affected tools:** `list-students`, `list-assignments` (with submission data), `list-assignment-submissions`, `list-section-submissions`, `list-rubric-assessments`, `get-submission-documents`
+
+Each affected tool accepts an `anonymous` parameter (default: `true`). Your AI assistant sets `anonymous: false` when you ask for real names.
+
+<details>
+<summary>Why teachers and admins are not anonymized</summary>
+
+The anonymization system targets **student privacy** while preserving educational context:
+
+- Students are the protected population whose privacy needs safeguarding
+- Knowing which instructor provided feedback is pedagogically valuable
+- Comments include an `author.role` field — only `role === 'student'` authors are anonymized
+
+Example with anonymization enabled:
+```
+✅ "Excellent analysis! - Prof. Johnson"
+❌ "I found this confusing - Student 1"
+```
+
+If you need full anonymization including staff, you can modify the logic in [`src/anonymizer.ts`](src/anonymizer.ts).
+</details>
+
+## Tool Reference
+
+| Category | Count | Tools |
+|----------|-------|-------|
+| Courses | 2 | `list-courses`, `post-announcement` |
+| Students | 1 | `list-students` |
+| Assignments | 5 | `list-assignments`, `get-assignment`, `create-assignment`, `update-assignment`, `delete-assignment` |
+| Assignment Groups | 3 | `list-assignment-groups`, `create-assignment-group`, `bulk-update-assignment-dates` |
+| Submissions | 6 | `list-assignment-submissions`, `grade-submission`, `post-submission-comment`, `get-submission-documents`, `get-submission-file-info`, `download-submission-file` |
+| Sections | 2 | `list-sections`, `list-section-submissions` |
+| Rubrics | 4 | `list-rubrics`, `get-rubric-statistics`, `list-rubric-assessments`, `attach-rubric-to-assignment` |
+| Modules | 10 | `list-modules`, `list-module-items`, `toggle-module-publish`, `create-module`, `update-module`, `delete-module`, `get-module-item`, `create-module-item`, `update-module-item`, `delete-module-item` |
+| Pages | 9 | `list-pages`, `get-page-content`, `update-page-content`, `list-page-revisions`, `revert-page-revision`, `patch-page-content`, `apply-page-changes`, `generate-styleguide`, `get-styleguide` |
+| Quizzes | 15 | `list-quizzes`, `get-quiz`, `create-quiz`, `update-quiz`, `delete-quiz`, `list-quiz-questions`, `get-quiz-question`, `create-quiz-question`, `update-quiz-question`, `delete-quiz-question`, `list-quiz-question-groups`, `get-quiz-question-group`, `create-quiz-question-group`, `update-quiz-question-group`, `delete-quiz-question-group` |
+| ePortfolios | 3 | `list-eportfolios`, `get-eportfolio`, `get-eportfolio-pages` |
+
+**Full parameter reference:** [docs/TOOLS.md](docs/TOOLS.md)
 
 ## Available Prompts
 
 ### analyze-rubric-statistics
-Analyzes rubric statistics for formative assignments in a course and creates visualizations
-- Required parameters:
-  - courseName: string (The name of the course to analyze)
-- Creates two comprehensive visualizations:
-  1. Grouped stacked bar chart showing score distribution per criterion across all assignments
-  2. Grouped bar chart showing average scores per criterion for all assignments
-- Provides comparative analysis across assignments and criteria
+
+Analyzes rubric statistics for formative assignments in a course and creates visualizations.
+
+- Required: `courseName` (string)
+- Creates grouped stacked bar and grouped bar charts across assignments and criteria
 - Includes progression analysis and trend identification
 
 ## Troubleshooting
 
-### Common Issues
+### Server not appearing in Claude Desktop
 
-1. Server not appearing in Claude Desktop:
-   - Verify configuration file syntax
-   - Check file paths are absolute
-   - Ensure Canvas API token is valid
-   - Restart Claude Desktop
+- Verify JSON syntax in your config file
+- Use absolute paths for source installs (`dist/index.js`, not `build/index.js`)
+- Ensure your Canvas API token is valid
+- Restart Claude Desktop
 
-2. Connection errors:
-   - Check Canvas API token permissions
-   - Verify Canvas instance is accessible
-   - Review Claude's MCP logs:
-     ```bash
-     # MacOS
-     tail -f ~/Library/Logs/Claude/mcp*.log
-     # Windows
-     type %AppData%\Claude\Logs\mcp*.log
-     ```
+### Connection errors
 
-### Debug Logging
-The server logs errors to stderr. These can be viewed in Claude Desktop's logs or redirected when running manually:
+- Confirm your token has access to the target courses
+- Verify `CANVAS_BASE_URL` points to your institution's Canvas instance
+- Check MCP logs:
+  ```bash
+  # macOS
+  tail -f ~/Library/Logs/Claude/mcp*.log
+  # Windows
+  type %AppData%\Claude\Logs\mcp*.log
+  ```
+
+### NPX issues
+
+- On Windows, ensure npm/npx are on your PATH
+- For permission errors, try running Claude Desktop as administrator (Windows)
+- Corporate networks may require npm proxy configuration
+
+### Debug logging
+
+The server logs errors to stderr. Redirect when running manually:
+
 ```bash
-node build/index.js 2> debug.log
+node dist/index.js 2> debug.log
 ```
 
 ## Performance & Caching
 
-The server caches all stable Canvas API responses to avoid redundant fetches and reduce token consumption.
+The server caches stable Canvas API responses to avoid redundant fetches and reduce token consumption.
 
 **How it works:**
 
-- On the first request for a resource, the response body and any `ETag` or `Last-Modified` header are stored in memory.
-- On subsequent requests for the same resource, the server sends a conditional GET (`If-None-Match` / `If-Modified-Since`). Canvas returns `304 Not Modified` with no body when the data hasn't changed — saving the bandwidth and tokens that would otherwise be spent re-sending identical content.
-- If Canvas doesn't return validator headers, a 30-minute TTL is used as a fallback.
-- Write operations (`POST`, `PUT`, `DELETE`) automatically evict affected cache entries so the next read always reflects the latest state.
+- First request stores the response body and any `ETag` or `Last-Modified` header
+- Subsequent requests send conditional GETs (`If-None-Match` / `If-Modified-Since`); Canvas returns `304 Not Modified` when data is unchanged
+- If Canvas omits validator headers, a 30-minute TTL is used as fallback
+- Write operations (`POST`, `PUT`, `DELETE`) evict affected cache entries
 
 **What is never cached:**
-- Submission and grade data (`/submissions` endpoints) — always fetched live.
+
+- Submission and grade data (`/submissions` endpoints) — always fetched live
+- Paginated `fetchAllPages()` calls (students, submissions, ePortfolios) bypass the ETag cache and always hit the network — relevant for large courses
 
 ## Development
 
-This MCP server uses the Model Context Protocol TypeScript SDK (v1.29.0). Each tool is registered with `server.tool()` using a five-argument form that includes tool annotations, which hint to MCP clients whether a tool is read-only, destructive, or idempotent:
+### Architecture
+
+```
+MCP Client → stdio → src/index.ts → src/tools/* → CanvasClient → Canvas REST API
+```
+
+Key modules:
+- [`src/index.ts`](src/index.ts) — server bootstrap and tool registration
+- [`src/canvasClient.ts`](src/canvasClient.ts) — HTTP client, ETag caching, pagination
+- [`src/anonymizer.ts`](src/anonymizer.ts) — student data pseudonymization
+- [`src/tools/`](src/tools/) — one file per domain, each exports `register*Tools()`
+
+### Tool registration
+
+This server uses the MCP TypeScript SDK (v1.29.0). Each tool is registered with `server.tool()` using a five-argument form:
 
 1. Tool name (string)
 2. Tool description (string)
@@ -797,7 +365,6 @@ server.tool(
   {},
   { readOnlyHint: true },
   async () => {
-    // Tool implementation...
     return {
       content: [{ type: "text", text: "..." }]
     };
@@ -805,37 +372,42 @@ server.tool(
 );
 ```
 
+### Local development
+
+```bash
+npm install
+npm run build    # compile TypeScript to dist/
+npm start        # run compiled server
+npm run dev      # run from source with tsx (hot reload)
+```
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Install dependencies: `npm install`
+4. Build: `npm run build`
+5. Submit a pull request
+
+There is currently no automated test suite — manual verification via an MCP client is the primary testing approach.
+
 ## Security Notes
 
-1. API Token Security:
+1. **API token security**
    - Never commit your Canvas API token to version control
    - Use environment variables or secure configuration
-   - Regularly rotate your API tokens
-   
-2. Permissions:
-   - Use tokens with minimum required permissions
+   - Rotate tokens periodically
+
+2. **Permissions**
+   - Use tokens with the minimum access needed for your use case
    - Review Canvas API access logs periodically
+
+## Related Documentation
+
+- [docs/TOOLS.md](docs/TOOLS.md) — full tool parameter reference
+- [DESKTOP_EXTENSION.md](DESKTOP_EXTENSION.md) — building and packaging the Claude Desktop Extension
+- [.env.example](.env.example) — environment variable template
 
 ## License
 
-MIT License
-
-Copyright (c) 2024
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+MIT — see [LICENSE](LICENSE).

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,0 +1,502 @@
+# Canvas MCP Tool Reference
+
+Full parameter reference for all **60 tools** exposed by the Canvas MCP server. For setup and usage, see the [README](../README.md).
+
+## Courses
+
+### list-courses
+Lists all active courses for the authenticated user.
+- No required parameters
+- Returns course names, IDs, and term information
+
+### post-announcement
+Posts an announcement to a specific course.
+- Required parameters:
+  - `courseId`: string
+  - `title`: string
+  - `message`: string
+
+## Students
+
+### list-students
+Gets a complete list of students enrolled in a course.
+- Required parameters:
+  - `courseId`: string
+- Optional parameters:
+  - `includeEmail`: boolean (default: false)
+  - `anonymous`: boolean (default: true) — whether to anonymize student names/emails
+- Returns student names, IDs, and optional email addresses
+- **Privacy**: Student data is anonymized by default (use "with actual names" to override)
+
+## Assignments
+
+### list-assignments
+Gets all assignments in a course with submission status.
+- Required parameters:
+  - `courseId`: string
+- Optional parameters:
+  - `studentId`: string
+  - `includeSubmissionHistory`: boolean (default: false)
+  - `anonymous`: boolean (default: true) — whether to anonymize student data in submissions
+- Returns assignment details and submission status
+- **Privacy**: Student submission data is anonymized by default
+
+### get-assignment
+Fetches metadata for a single assignment.
+- Required parameters:
+  - `courseId`: string
+  - `assignmentId`: string
+- Returns due date, points, grading type, submission types, rubric presence, and publish state
+
+### create-assignment
+Creates a new assignment in a course.
+- Required parameters:
+  - `courseId`: string
+- Optional parameters:
+  - `name`, `description`, `due_at`, `points_possible`, `submission_types`, `published`, `grading_type`, `assignment_group_id`
+
+### update-assignment
+Updates an existing assignment.
+- Required parameters:
+  - `courseId`: string
+  - `assignmentId`: string
+- Optional parameters: same as `create-assignment`
+
+### delete-assignment
+Deletes (archives) an assignment from a course.
+- Required parameters:
+  - `courseId`: string
+  - `assignmentId`: string
+
+## Assignment Groups
+
+### list-assignment-groups
+Lists all assignment groups (grade buckets) in a course.
+- Required parameters:
+  - `courseId`: string
+- Returns group name, ID, position, weight, and drop rules
+
+### create-assignment-group
+Creates a new assignment group in a course.
+- Required parameters:
+  - `courseId`: string
+- Optional parameters:
+  - `name`, `position`, `group_weight`, `sis_source_id`, `rules`
+
+### bulk-update-assignment-dates
+Updates due/unlock/lock dates for multiple assignments in one call.
+- Required parameters:
+  - `courseId`: string
+  - `assignmentDates`: array of `{ assignment_id, due_at?, unlock_at?, lock_at? }`
+
+## Submissions
+
+### grade-submission
+Writes a score, grade, rubric assessment, or comment for a student's submission.
+- Required parameters:
+  - `courseId`: string
+  - `assignmentId`: string
+  - `userId`: string
+- Optional parameters:
+  - `posted_grade`, `score`, `rubric_assessment`, `comment`
+
+### list-assignment-submissions
+Gets all student submissions for a specific assignment.
+- Required parameters:
+  - `courseId`: string
+  - `assignmentId`: string
+- Optional parameters:
+  - `anonymous`: boolean (default: true) — whether to anonymize student names/emails
+- Returns submission details, grades, and comments
+- **Privacy**: Student data is anonymized by default
+
+### get-submission-documents
+Retrieves a student's submission with attachment metadata and optional file content.
+- Required parameters:
+  - `courseId`: string
+  - `assignmentId`: string
+  - `userId`: string
+- Optional parameters:
+  - `downloadFiles`: boolean (default: false)
+  - `anonymous`: boolean (default: true)
+
+### get-submission-file-info
+Returns metadata for a specific file attached to a submission.
+- Required parameters:
+  - `fileId`: string
+
+### download-submission-file
+Downloads a submission file as text or base64.
+- Required parameters:
+  - `fileId`: string
+- Optional parameters:
+  - `forceBase64`: boolean (default: false)
+
+### post-submission-comment
+Posts a comment on a student's assignment submission.
+- Required parameters:
+  - `courseId`: string
+  - `assignmentId`: string
+  - `studentId`: string
+  - `comment`: string
+- Returns confirmation of the posted comment
+
+## Sections
+
+### list-sections
+Gets a list of all sections in a course.
+- Required parameters:
+  - `courseId`: string
+- Optional parameters:
+  - `includeStudentCount`: boolean (default: false)
+- Returns section details with optional student count
+
+### list-section-submissions
+Gets all student submissions for a specific assignment filtered by section.
+- Required parameters:
+  - `courseId`: string
+  - `assignmentId`: string
+  - `sectionId`: string
+- Optional parameters:
+  - `includeComments`: boolean (default: true)
+  - `anonymous`: boolean (default: true) — whether to anonymize student names/emails
+- Returns submission details filtered by the specified section
+- **Privacy**: Student data is anonymized by default
+
+## Rubrics
+
+### list-rubrics
+Lists all rubrics for a specific course.
+- Required parameters:
+  - `courseId`: string
+- Returns rubric titles, IDs, and descriptions
+
+### get-rubric-statistics
+Gets statistics for rubric assessments on an assignment.
+- Required parameters:
+  - `courseId`: string
+  - `assignmentId`: string
+- Optional parameters:
+  - `includePointDistribution`: boolean (default: true)
+- Returns overall and per-criterion statistics including average, median, min, max, and score distribution
+
+### list-rubric-assessments
+Lists all rubric assessments for an assignment.
+- Required parameters:
+  - `courseId`: string
+  - `assignmentId`: string
+- Optional parameters:
+  - `anonymous`: boolean (default: true)
+- Returns per-submission rubric scores and criteria ratings
+
+### attach-rubric-to-assignment
+Attaches an existing rubric to an assignment.
+- Required parameters:
+  - `courseId`: string
+  - `assignmentId`: string
+  - `rubricId`: string
+
+## Modules
+
+### list-modules
+Lists all modules in a course, optionally including inline items.
+- Required parameters:
+  - `courseId`: string
+- Optional parameters:
+  - `includeItems`: boolean (default: false)
+- Returns module names, IDs, positions, published state, and optionally item summaries
+
+### list-module-items
+Lists all items in a specific module.
+- Required parameters:
+  - `courseId`: string
+  - `moduleId`: string
+- Returns item type, title, ID, position, and published state
+
+### toggle-module-publish
+Toggles the published/unpublished state of a module.
+- Required parameters:
+  - `courseId`: string
+  - `moduleId`: string
+- Returns confirmation of the new published state
+
+### create-module
+Creates a new module in a course.
+- Required parameters:
+  - `courseId`: string
+  - `name`: string
+- Optional parameters:
+  - `position`: number (1-based)
+  - `unlock_at`: string (ISO 8601 date)
+  - `require_sequential_progress`: boolean
+  - `prerequisite_module_ids`: string[]
+  - `publish_final_grade`: boolean
+- Returns the created module's ID, name, position, and published state
+
+### update-module
+Updates an existing module's properties.
+- Required parameters:
+  - `courseId`: string
+  - `moduleId`: string
+- Optional parameters:
+  - `name`, `position`, `unlock_at`, `require_sequential_progress`, `prerequisite_module_ids`, `publish_final_grade`, `published`
+- Returns the updated module's ID, name, position, and published state
+
+### delete-module
+Permanently deletes a module and all its items from a course.
+- Required parameters:
+  - `courseId`: string
+  - `moduleId`: string
+- Returns confirmation of deletion
+
+### get-module-item
+Gets details for a single module item.
+- Required parameters:
+  - `courseId`: string
+  - `moduleId`: string
+  - `itemId`: string
+- Returns item ID, type, title, position, content_id, published state, indent, external_url, page_url, and completion requirement
+
+### create-module-item
+Adds a new item to a module.
+- Required parameters:
+  - `courseId`: string
+  - `moduleId`: string
+  - `type`: one of `File`, `Page`, `Discussion`, `Assignment`, `Quiz`, `SubHeader`, `ExternalUrl`, `ExternalTool`
+- Optional parameters:
+  - `content_id`, `title`, `position`, `indent`, `page_url`, `external_url`, `new_tab`
+  - `completion_requirement_type`: `must_view` | `must_contribute` | `must_submit` | `must_mark_done`
+  - `completion_requirement_min_score`: number
+- Returns the created item's ID, type, title, and position
+
+### update-module-item
+Updates an existing module item.
+- Required parameters:
+  - `courseId`: string
+  - `moduleId`: string
+  - `itemId`: string
+- Optional parameters:
+  - `title`, `position`, `indent`, `external_url`, `new_tab`, `published`
+  - `move_to_module_id`: string (moves the item to a different module)
+  - `completion_requirement_type`, `completion_requirement_min_score`
+- Returns the updated item's ID, type, title, position, and published state
+
+### delete-module-item
+Removes an item from a module.
+- Required parameters:
+  - `courseId`: string
+  - `moduleId`: string
+  - `itemId`: string
+- Returns confirmation of deletion
+
+## Pages
+
+### list-pages
+Lists all pages in a course by URL slug.
+- Required parameters:
+  - `courseId`: string
+- Returns page titles, URL slugs, IDs, and published state
+
+### get-page-content
+Gets the content (HTML/body) of a specific page by URL slug.
+- Required parameters:
+  - `courseId`: string
+  - `pageUrl`: string (the page's URL slug, e.g. `syllabus`)
+- Returns page title, slug, ID, published state, updated date, and HTML body
+
+### update-page-content
+Updates (or creates) a page by URL slug.
+- Required parameters:
+  - `courseId`: string
+  - `pageUrl`: string
+- Optional parameters:
+  - `title`: string
+  - `body`: string (HTML)
+  - `editingRoles`: string (comma-separated roles)
+- Returns confirmation and updated page info
+
+### list-page-revisions
+Lists all revisions for a page.
+- Required parameters:
+  - `courseId`: string
+  - `pageUrl`: string
+- Returns revision IDs, timestamps, and editor info
+
+### revert-page-revision
+Reverts a page to a previous revision.
+- Required parameters:
+  - `courseId`: string
+  - `pageUrl`: string
+  - `revisionId`: string
+- Returns confirmation and new page state
+
+### patch-page-content
+Applies targeted edits to a page using find-and-replace or section-level instructions.
+- Required parameters:
+  - `courseId`: string
+  - `pageUrl`: string
+  - `instructions`: string
+- Returns the updated page body
+
+### apply-page-changes
+Applies a set of structured diffs to a page (bulk patch).
+- Required parameters:
+  - `courseId`: string
+  - `pageUrl`: string
+  - `changes`: array of `{ find, replace }` pairs
+
+### generate-styleguide
+Generates a course styleguide page from existing page content.
+- Required parameters:
+  - `courseId`: string
+- Analyzes existing pages and writes a `styleguide` page capturing fonts, colors, and layout conventions
+
+### get-styleguide
+Retrieves the styleguide page for a course.
+- Required parameters:
+  - `courseId`: string
+
+## Quizzes
+
+### list-quizzes
+Lists all quizzes in a course.
+- Required parameters:
+  - `courseId`: string
+- Returns a list of quizzes with their details
+
+### get-quiz
+Fetches metadata for a single quiz.
+- Required parameters:
+  - `courseId`: string
+  - `quizId`: string
+- Returns the full quiz object
+
+### create-quiz
+Creates a new quiz in a course.
+- Required parameters:
+  - `courseId`: string
+  - `title`: string
+- Optional parameters:
+  - `description`: string
+  - `quiz_type`: `"practice_quiz"` | `"assignment"` | `"graded_survey"` | `"survey"`
+  - `due_at`: string (ISO 8601 format)
+  - `points_possible`: number
+  - `published`: boolean
+- Returns the newly created quiz object
+
+### update-quiz
+Updates an existing quiz.
+- Required parameters:
+  - `courseId`: string
+  - `quizId`: string
+- Optional parameters: same as `create-quiz`
+- Returns the updated quiz object
+
+### delete-quiz
+Deletes a quiz.
+- Required parameters:
+  - `courseId`: string
+  - `quizId`: string
+- Returns confirmation of deletion
+
+### list-quiz-questions
+Lists all questions for a quiz.
+- Required parameters:
+  - `courseId`: string
+  - `quizId`: string
+- Returns a list of question objects
+
+### get-quiz-question
+Fetches a single quiz question.
+- Required parameters:
+  - `courseId`: string
+  - `quizId`: string
+  - `questionId`: string
+- Returns the full question object
+
+### create-quiz-question
+Creates a new question for a quiz.
+- Required parameters:
+  - `courseId`: string
+  - `quizId`: string
+  - `question`: object (containing `question_text`, `question_type`, `points_possible`, etc.)
+- Returns the newly created question object
+
+### update-quiz-question
+Updates a quiz question.
+- Required parameters:
+  - `courseId`: string
+  - `quizId`: string
+  - `questionId`: string
+- Optional parameters:
+  - `question`: object (with fields to update)
+- Returns the updated question object
+
+### delete-quiz-question
+Deletes a quiz question.
+- Required parameters:
+  - `courseId`: string
+  - `quizId`: string
+  - `questionId`: string
+- Returns confirmation of deletion
+
+### list-quiz-question-groups
+Lists all question groups for a quiz.
+- Required parameters:
+  - `courseId`: string
+  - `quizId`: string
+- Returns a list of question group objects
+
+### get-quiz-question-group
+Fetches a single quiz question group.
+- Required parameters:
+  - `courseId`: string
+  - `quizId`: string
+  - `groupId`: string
+- Returns the full question group object
+
+### create-quiz-question-group
+Creates a new question group for a quiz.
+- Required parameters:
+  - `courseId`: string
+  - `quizId`: string
+  - `quizGroup`: object (containing `name`, `pick_count`, `question_points`)
+- Returns the newly created question group object
+
+### update-quiz-question-group
+Updates a quiz question group.
+- Required parameters:
+  - `courseId`: string
+  - `quizId`: string
+  - `groupId`: string
+- Optional parameters:
+  - `quizGroup`: object (with fields to update)
+- Returns the updated question group object
+
+### delete-quiz-question-group
+Deletes a quiz question group.
+- Required parameters:
+  - `courseId`: string
+  - `quizId`: string
+  - `groupId`: string
+- Returns confirmation of deletion
+
+## ePortfolios
+
+### list-eportfolios
+Lists all ePortfolios belonging to a user.
+- Required parameters:
+  - `userId`: string
+- Returns ePortfolio ID, name, public flag, workflow state, and timestamps
+
+### get-eportfolio
+Gets details for a single ePortfolio.
+- Required parameters:
+  - `eportfolioId`: string
+- Returns ID, user_id, name, public flag, workflow state, spam status, and timestamps
+
+### get-eportfolio-pages
+Lists all pages in an ePortfolio.
+- Required parameters:
+  - `eportfolioId`: string
+- Returns page ID, eportfolio_id, position, name, content, and timestamps

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "mcpb_version": "0.1",
   "name": "canvas-mcp",
   "display_name": "Canvas LMS Integration",
-  "version": "1.0.8",
+  "version": "1.2.0",
   "description": "Comprehensive Canvas LMS integration for course management, assignments, pages, students, and rubric analysis",
   "long_description": "This extension provides full Canvas LMS integration capabilities including course management, assignment creation and grading, page editing with styleguide support, student management with privacy controls, module organization, submission tracking, and comprehensive rubric statistics analysis. Perfect for educators who want to streamline their Canvas workflows directly from Claude Desktop.",
   "author": {
@@ -47,62 +47,66 @@
     }
   },
   "tools": [
-    {
-      "name": "list-courses",
-      "description": "List all available courses for the authenticated user"
-    },
-    {
-      "name": "list-assignments", 
-      "description": "Get assignments with submission status for students"
-    },
-    {
-      "name": "create-assignment",
-      "description": "Create new assignments in a course"
-    },
-    {
-      "name": "update-assignment", 
-      "description": "Update existing assignments"
-    },
-    {
-      "name": "list-students",
-      "description": "Get course enrollment with privacy controls"
-    },
-    {
-      "name": "generate-styleguide",
-      "description": "🎨 Create comprehensive Canvas page formatting standards"
-    },
-    {
-      "name": "update-page-content",
-      "description": "Create or update course pages with styleguide compliance"
-    },
-    {
-      "name": "patch-page-content", 
-      "description": "Smart editing of existing pages using natural language"
-    },
-    {
-      "name": "get-rubric-statistics",
-      "description": "Comprehensive rubric analysis with score distributions"
-    },
-    {
-      "name": "list-assignment-submissions",
-      "description": "Track student submission status and comments"
-    },
-    {
-      "name": "grade-submission",
-      "description": "Grade student work with scores and feedback"
-    },
-    {
-      "name": "list-modules",
-      "description": "Course module management and organization"
-    },
-    {
-      "name": "list-sections", 
-      "description": "Course section management"
-    },
-    {
-      "name": "post-announcement",
-      "description": "Post course announcements"
-    }
+    { "name": "list-courses", "description": "List all active courses for the authenticated user" },
+    { "name": "post-announcement", "description": "Post an announcement to a specific course" },
+    { "name": "list-students", "description": "Get course enrollment with privacy controls" },
+    { "name": "list-assignments", "description": "Get assignments with submission status for students" },
+    { "name": "get-assignment", "description": "Fetch metadata for a single assignment" },
+    { "name": "create-assignment", "description": "Create new assignments in a course" },
+    { "name": "update-assignment", "description": "Update existing assignments" },
+    { "name": "delete-assignment", "description": "Delete (archive) an assignment" },
+    { "name": "list-assignment-groups", "description": "List assignment groups (grade buckets) in a course" },
+    { "name": "create-assignment-group", "description": "Create a new assignment group" },
+    { "name": "bulk-update-assignment-dates", "description": "Bulk update due/unlock/lock dates for assignments" },
+    { "name": "list-assignment-submissions", "description": "Track student submission status and comments" },
+    { "name": "grade-submission", "description": "Grade student work with scores and feedback" },
+    { "name": "post-submission-comment", "description": "Post feedback as a comment on a submission" },
+    { "name": "get-submission-documents", "description": "Retrieve submission attachments and optional file content" },
+    { "name": "get-submission-file-info", "description": "Get metadata for a submission file" },
+    { "name": "download-submission-file", "description": "Download a submission file as text or base64" },
+    { "name": "list-sections", "description": "List course sections with optional enrollment counts" },
+    { "name": "list-section-submissions", "description": "Get submissions filtered by section" },
+    { "name": "list-rubrics", "description": "List all rubrics in a course" },
+    { "name": "get-rubric-statistics", "description": "Rubric analysis with score distributions" },
+    { "name": "list-rubric-assessments", "description": "List rubric assessments for an assignment" },
+    { "name": "attach-rubric-to-assignment", "description": "Attach a rubric to an assignment" },
+    { "name": "list-modules", "description": "Course module management and organization" },
+    { "name": "list-module-items", "description": "List items in a module" },
+    { "name": "toggle-module-publish", "description": "Publish or unpublish a module" },
+    { "name": "create-module", "description": "Create a new module" },
+    { "name": "update-module", "description": "Update module properties" },
+    { "name": "delete-module", "description": "Delete a module and its items" },
+    { "name": "get-module-item", "description": "Get details for a module item" },
+    { "name": "create-module-item", "description": "Add an item to a module" },
+    { "name": "update-module-item", "description": "Update a module item" },
+    { "name": "delete-module-item", "description": "Remove an item from a module" },
+    { "name": "list-pages", "description": "List course pages by URL slug" },
+    { "name": "get-page-content", "description": "Get page HTML content" },
+    { "name": "update-page-content", "description": "Create or update course pages" },
+    { "name": "list-page-revisions", "description": "List page revision history" },
+    { "name": "revert-page-revision", "description": "Revert a page to a previous revision" },
+    { "name": "patch-page-content", "description": "Smart editing of pages using natural language" },
+    { "name": "apply-page-changes", "description": "Write revised HTML to a Canvas page" },
+    { "name": "generate-styleguide", "description": "Create Canvas page formatting standards" },
+    { "name": "get-styleguide", "description": "Fetch the course styleguide page" },
+    { "name": "list-quizzes", "description": "List all quizzes in a course" },
+    { "name": "get-quiz", "description": "Fetch metadata for a single quiz" },
+    { "name": "create-quiz", "description": "Create a new quiz" },
+    { "name": "update-quiz", "description": "Update an existing quiz" },
+    { "name": "delete-quiz", "description": "Delete a quiz" },
+    { "name": "list-quiz-questions", "description": "List questions in a quiz" },
+    { "name": "get-quiz-question", "description": "Fetch a single quiz question" },
+    { "name": "create-quiz-question", "description": "Create a quiz question" },
+    { "name": "update-quiz-question", "description": "Update a quiz question" },
+    { "name": "delete-quiz-question", "description": "Delete a quiz question" },
+    { "name": "list-quiz-question-groups", "description": "List question groups in a quiz" },
+    { "name": "get-quiz-question-group", "description": "Fetch a quiz question group" },
+    { "name": "create-quiz-question-group", "description": "Create a quiz question group" },
+    { "name": "update-quiz-question-group", "description": "Update a quiz question group" },
+    { "name": "delete-quiz-question-group", "description": "Delete a quiz question group" },
+    { "name": "list-eportfolios", "description": "List ePortfolios for a user" },
+    { "name": "get-eportfolio", "description": "Get ePortfolio details" },
+    { "name": "get-eportfolio-pages", "description": "List pages in an ePortfolio" }
   ],
   "prompts": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@r-huijts/canvas-mcp",
       "version": "1.2.0",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.6.7",
@@ -19,6 +20,7 @@
       "devDependencies": {
         "@anthropic-ai/dxt": "^0.1.0",
         "@types/node": "^20.17.10",
+        "tsx": "^4.19.2",
         "typescript": "^5.7.2"
       }
     },
@@ -37,6 +39,448 @@
       },
       "bin": {
         "dxt": "dist/cli/cli.js"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@hono/node-server": {
@@ -800,6 +1244,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1050,6 +1536,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1754,6 +2255,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,13 @@
 {
   "name": "@r-huijts/canvas-mcp",
   "version": "1.2.0",
+  "description": "MCP server for Canvas LMS — courses, assignments, grading, pages, rubrics, and more",
+  "author": "R.Huijts",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/r-huijts/canvas-mcp"
+  },
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -22,6 +29,7 @@
   "devDependencies": {
     "@anthropic-ai/dxt": "^0.1.0",
     "@types/node": "^20.17.10",
+    "tsx": "^4.19.2",
     "typescript": "^5.7.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ dotenv.config();
 // Create the MCP server
 const server = new McpServer({
   name: "Canvas MCP Server",
-  version: "1.0.0"
+  version: "1.2.0"
 });
 
 // Read configuration from environment variables


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the README improvement plan: restructures documentation for scannability, fixes factual errors, and syncs related project metadata.

## README changes

- Added badges, Quick Start, Table of Contents, and a one-line value proposition
- Condensed privacy section with collapsible details for teacher/admin rationale
- Split the 60-tool parameter reference into [`docs/TOOLS.md`](docs/TOOLS.md); README now has a category summary table
- Added sections: Configuration, Other MCP Clients, Usage Examples, Contributing, Related Documentation
- Fixed `build/` → `dist/` paths, placeholder clone URL, and hardcoded extension version
- Documented `fetchAllPages()` caching caveat and development architecture
- Replaced inline MIT license text with a link to [`LICENSE`](LICENSE)

## Code/config sync

- Synced version to `1.2.0` in `package.json`, `manifest.json`, and `src/index.ts`
- Added `tsx` to devDependencies so `npm run dev` works
- Expanded `manifest.json` tool list from 14 to all 60 tools
- Added `package.json` metadata (description, author, license, repository)
- Fixed placeholder issues URL in `DESKTOP_EXTENSION.md`

## Verification

- `npm install` — passes
- `npm run build` — passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f178e-31e4-77c9-94d9-829009a0ab3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f178e-31e4-77c9-94d9-829009a0ab3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

