### PR TITLE
Fix pagination bugs, trim token usage, harden cache, tighten anonymization

### DIFF
--- a/src/anonymizer.ts
+++ b/src/anonymizer.ts
@@ -18,12 +18,22 @@ export class DataAnonymizer {
 
     const anonymizedName = this.userNameMap.get(userId);
 
-    return {
+    const anonymized: any = {
       ...user,
       name: anonymizedName,
       display_name: anonymizedName,
-      email: user.email ? `student${userId}@example.com` : undefined
+      short_name: anonymizedName,
+      sortable_name: anonymizedName,
+      email: user.email ? `student${userId}@example.com` : undefined,
     };
+    // Strip fields that would re-identify an otherwise anonymized student.
+    // (user.id / user_id are kept — they're needed to grade or comment.)
+    delete anonymized.sis_user_id;
+    delete anonymized.integration_id;
+    delete anonymized.login_id;
+    delete anonymized.avatar_url;
+    delete anonymized.pronouns;
+    return anonymized;
   }
 
   /**

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,10 +1,13 @@
-const FALLBACK_TTL_MS = 30 * 60 * 1000; // 30 min, used only when Canvas returns no ETag
+const FALLBACK_TTL_MS = 30 * 60 * 1000; // hard expiry for entries with no ETag/Last-Modified
+const FRESH_MS = 60 * 1000; // serve any cached entry without revalidation for this long
+const MAX_ENTRIES = 500; // LRU cap to keep memory bounded on a long-lived server
 
 export interface CacheEntry {
   value: any;
   etag?: string;
   lastModified?: string;
-  expiresAt: number;
+  freshUntil: number; // serve without a network call until this time
+  expiresAt: number; // hard expiry, only applied to entries without a validator
 }
 
 export class SimpleCache {
@@ -13,16 +16,32 @@ export class SimpleCache {
   get(key: string): CacheEntry | undefined {
     const entry = this.store.get(key);
     if (!entry) return undefined;
+    const hasValidator = !!(entry.etag || entry.lastModified);
     // TTL only applies when there are no conditional-GET validators
-    if (!entry.etag && !entry.lastModified && Date.now() > entry.expiresAt) {
+    if (!hasValidator && Date.now() > entry.expiresAt) {
       this.store.delete(key);
       return undefined;
     }
+    // Mark as most-recently used (re-insert to move to the end of the Map)
+    this.store.delete(key);
+    this.store.set(key, entry);
     return entry;
   }
 
   set(key: string, value: any, etag?: string, lastModified?: string): void {
-    this.store.set(key, { value, etag, lastModified, expiresAt: Date.now() + FALLBACK_TTL_MS });
+    const now = Date.now();
+    this.store.delete(key);
+    this.store.set(key, { value, etag, lastModified, freshUntil: now + FRESH_MS, expiresAt: now + FALLBACK_TTL_MS });
+    // Evict the least-recently-used entry (first key) once over capacity
+    if (this.store.size > MAX_ENTRIES) {
+      const oldest = this.store.keys().next().value;
+      if (oldest !== undefined) this.store.delete(oldest);
+    }
+  }
+
+  // Whether an entry can be served without revalidating against Canvas
+  isFresh(entry: CacheEntry): boolean {
+    return Date.now() < entry.freshUntil;
   }
 
   invalidatePrefix(prefix: string): void {

--- a/src/canvasClient.ts
+++ b/src/canvasClient.ts
@@ -28,8 +28,12 @@ export class CanvasClient {
   private invalidateForWrite(url: string): void {
     const basePath = url.split('?')[0];
     this.cache.invalidatePrefix(basePath);
+    // Refresh the containing collection list (e.g. updating /pages/syllabus
+    // should drop the cached /pages list), but never climb so high that a
+    // single write wipes an entire course or the API root.
     const parent = basePath.replace(/\/[^/]+$/, '');
-    if (parent !== basePath) this.cache.invalidatePrefix(parent);
+    const tooBroad = /^\/api\/v1\/courses\/\d+$/.test(parent) || /^\/api\/v1\/[^/]+$/.test(parent);
+    if (parent !== basePath && !tooBroad) this.cache.invalidatePrefix(parent);
   }
 
   // Generic GET with ETag-based conditional requests and TTL fallback
@@ -38,8 +42,9 @@ export class CanvasClient {
     const key = this.cacheKey(url, params);
     const cached = cacheable ? this.cache.get(key) : undefined;
 
-    // TTL-only hit (no ETag/Last-Modified) — return without a network call
-    if (cached && !cached.etag && !cached.lastModified) {
+    // Serve without a network call when still fresh, or when there's no
+    // validator (the TTL-only path, already bounded by the cache's expiry)
+    if (cached && (this.cache.isFresh(cached) || !(cached.etag || cached.lastModified))) {
       return cached.value as T;
     }
 
@@ -110,8 +115,18 @@ export class CanvasClient {
     return links;
   }
 
-  // Fetch all pages for paginated endpoints using Link header
+  // Fetch all pages for paginated endpoints using Link header.
+  // The assembled result is cached (TTL-based) for cacheable URLs so repeated
+  // list calls don't re-download every page.
   async fetchAllPages<T>(url: string, params: any = {}): Promise<T[]> {
+    const cacheable = this.isCacheable(url);
+    const key = this.cacheKey(url, { ...params, __all: true });
+    if (cacheable) {
+      const cached = this.cache.get(key);
+      if (cached && (this.cache.isFresh(cached) || !(cached.etag || cached.lastModified))) {
+        return cached.value as T[];
+      }
+    }
     const results: T[] = [];
     const per_page = params.per_page || 100;
     let page = 1;
@@ -124,6 +139,7 @@ export class CanvasClient {
       if (!linkHeader || !this.parseLinkHeader(linkHeader).next) break;
       page++;
     }
+    if (cacheable) this.cache.set(key, results);
     return results;
   }
 

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -304,7 +304,7 @@ export function registerPageTools(server: McpServer, canvas: CanvasClient) {
   // Tool: update-page-content
   server.tool(
     "update-page-content",
-    "Update or create a page with new content, replacing the entire body. If no body is provided and showStyleguidePreview is true, returns the course styleguide HTML for reference instead of writing. For targeted edits to existing content, use patch-page-content instead.",
+    "Update or create a page with new content, replacing the entire body. If no body/title/editingRoles is provided, nothing is written and guidance is returned (set showStyleguidePreview to also inline the styleguide). For targeted edits to existing content, use patch-page-content instead.",
     {
       courseId: z.string().describe("The ID of the course"),
       pageUrl: z.string().describe("The page's URL slug (e.g., 'syllabus')"),
@@ -312,44 +312,48 @@ export function registerPageTools(server: McpServer, canvas: CanvasClient) {
       body: z.string().optional().describe("The new HTML body for the page (optional)"),
       editingRoles: z.string().optional().describe("Comma-separated roles allowed to edit (optional)"),
       ignoreStyleguide: z.boolean().default(false).describe("Skip styleguide reference (not recommended)"),
-      showStyleguidePreview: z.boolean().default(true).describe("Show styleguide preview when creating content from scratch")
+      showStyleguidePreview: z.boolean().default(false).describe("When no body is provided, inline the full course styleguide HTML for reference (off by default to save tokens; use get-styleguide to fetch it on demand)")
     },
     { idempotentHint: true },
-    async ({ courseId, pageUrl, title, body, editingRoles, ignoreStyleguide = false, showStyleguidePreview = true }: { 
-      courseId: string; 
-      pageUrl: string; 
-      title?: string; 
-      body?: string; 
+    async ({ courseId, pageUrl, title, body, editingRoles, ignoreStyleguide = false, showStyleguidePreview = false }: {
+      courseId: string;
+      pageUrl: string;
+      title?: string;
+      body?: string;
       editingRoles?: string;
       ignoreStyleguide?: boolean;
       showStyleguidePreview?: boolean;
     }) => {
       try {
-        // If creating content from scratch and no body provided, show styleguide for reference
-        if (!body && showStyleguidePreview && !ignoreStyleguide) {
-          try {
-            const styleguide = (await canvas.getPage(courseId, DEFAULT_STYLEGUIDE_SLUG) as any);
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: [
-                    `Creating new page '${pageUrl}' in course ${courseId}`,
-                    `Title: ${title || 'Not specified'}`,
-                    '',
-                    '--- COURSE STYLEGUIDE FOR REFERENCE ---',
-                    styleguide.body || 'No styleguide content found',
-                    '--- END STYLEGUIDE ---',
-                    '',
-                    'Please create the page content following the above styleguide standards for consistency.',
-                    'Use update-page-content again with the body parameter containing your HTML content.'
-                  ].join('\n')
-                }
-              ]
-            };
-          } catch (error) {
-            // Styleguide not found, continue with normal operation
+        // Nothing to write: don't create/clear a page by accident. Return guidance
+        // instead, and only inline the full styleguide when explicitly requested.
+        if (body === undefined && title === undefined && editingRoles === undefined) {
+          let styleguideBlock = '';
+          if (showStyleguidePreview && !ignoreStyleguide) {
+            try {
+              const styleguide = (await canvas.getPage(courseId, DEFAULT_STYLEGUIDE_SLUG) as any);
+              styleguideBlock = [
+                '',
+                '--- COURSE STYLEGUIDE FOR REFERENCE ---',
+                styleguide.body || 'No styleguide content found',
+                '--- END STYLEGUIDE ---'
+              ].join('\n');
+            } catch (error) {
+              // Styleguide not found, omit it
+            }
           }
+          return {
+            content: [
+              {
+                type: "text",
+                text: [
+                  `No content provided for page '${pageUrl}' in course ${courseId}; nothing was written.`,
+                  `Call update-page-content again with a 'body' (and optionally 'title') to save content.`,
+                  `A course styleguide is available via get-styleguide for formatting reference.${styleguideBlock}`
+                ].join('\n')
+              }
+            ]
+          };
         }
 
         const wiki_page: any = {};
@@ -463,25 +467,26 @@ export function registerPageTools(server: McpServer, canvas: CanvasClient) {
       instructions: z.string().describe("Natural language instructions for what changes to make to the page content (e.g., 'Update office hours to 2-4pm on MWF', 'Add a warning about the upcoming exam', 'Fix all typos')"),
       title: z.string().optional().describe("New title for the page (optional)"),
       editingRoles: z.string().optional().describe("Comma-separated roles allowed to edit (optional)"),
-      ignoreStyleguide: z.boolean().default(false).describe("Skip styleguide reference (not recommended)")
+      includeStyleguide: z.boolean().default(false).describe("Inline the full course styleguide HTML for reference (off by default to save tokens; fetch it on demand with get-styleguide)")
     },
     { readOnlyHint: true },
-    async ({ courseId, pageUrl, instructions, title, editingRoles, ignoreStyleguide = false }: { 
-      courseId: string; 
-      pageUrl: string; 
+    async ({ courseId, pageUrl, instructions, title, editingRoles, includeStyleguide = false }: {
+      courseId: string;
+      pageUrl: string;
       instructions: string;
       title?: string;
       editingRoles?: string;
-      ignoreStyleguide?: boolean;
+      includeStyleguide?: boolean;
     }) => {
       try {
         // Fetch the current page content
         const currentPage = (await canvas.getPage(courseId, pageUrl) as any);
         const currentBody = currentPage.body || '';
 
-        // Try to fetch styleguide unless explicitly ignored
-        let styleguideContext = '';
-        if (!ignoreStyleguide) {
+        // Only inline the (large) styleguide when explicitly requested; otherwise
+        // leave a short pointer so the model can fetch it via get-styleguide if needed.
+        let styleguideContext = '\n\nIf you need the course formatting standards, call get-styleguide.';
+        if (includeStyleguide) {
           try {
             const styleguide = (await canvas.getPage(courseId, DEFAULT_STYLEGUIDE_SLUG) as any);
             styleguideContext = `

--- a/src/tools/quizzes.ts
+++ b/src/tools/quizzes.ts
@@ -13,7 +13,7 @@ export function registerQuizTools(server: McpServer, canvas: CanvasClient) {
     { readOnlyHint: true },
     async ({ courseId }: { courseId: string; }) => {
       try {
-        const quizzes: any[] = await canvas.get(`/api/v1/courses/${courseId}/quizzes`);
+        const quizzes: any[] = await canvas.fetchAllPages(`/api/v1/courses/${courseId}/quizzes`, { per_page: 100 });
         const formattedQuizzes = quizzes
           .map((quiz: any) => {
             return [
@@ -177,7 +177,7 @@ export function registerQuizTools(server: McpServer, canvas: CanvasClient) {
     { readOnlyHint: true },
     async ({ courseId, quizId }: { courseId: string; quizId: string; }) => {
       try {
-        const questions: any[] = await canvas.get(`/api/v1/courses/${courseId}/quizzes/${quizId}/questions`);
+        const questions: any[] = await canvas.fetchAllPages(`/api/v1/courses/${courseId}/quizzes/${quizId}/questions`, { per_page: 100 });
         const formattedQuestions = questions
           .map((q: any) => {
             return `ID: ${q.id}, Type: ${q.question_type}, Text: ${q.question_text.substring(0, 100)}...`;

--- a/src/tools/sections.ts
+++ b/src/tools/sections.ts
@@ -82,27 +82,19 @@ export function registerSectionTools(server: McpServer, canvas: CanvasClient) {
     },
     { readOnlyHint: true },
     async ({ courseId, assignmentId, sectionId, includeComments = true, anonymous = true }: { courseId: string; assignmentId: string; sectionId: string; includeComments?: boolean; anonymous?: boolean }) => {
-      let submissions: any[] = [];
-      let page = 1;
-      let hasMore = true;
       try {
         await canvas.getSection(courseId, sectionId);
 
-        while (hasMore) {
-          const params: any = {
-            per_page: 100,
-            page: page,
-            include: [
-              'user',
-              'submission_comments',
-              'assignment'
-            ]
-          };
-          const pageSubmissions = (await canvas.listSectionAssignmentSubmissions(sectionId, assignmentId, params, { anonymous }) as any[]);
-          submissions.push(...pageSubmissions);
-          hasMore = pageSubmissions.length === 100;
-          page += 1;
-        }
+        // listSectionAssignmentSubmissions paginates internally.
+        const params: any = {
+          per_page: 100,
+          include: [
+            'user',
+            'submission_comments',
+            'assignment'
+          ]
+        };
+        const submissions = (await canvas.listSectionAssignmentSubmissions(sectionId, assignmentId, params, { anonymous }) as any[]);
         const formattedSubmissions = submissions
           .map(submission => {
             const parts = [

--- a/src/tools/students.ts
+++ b/src/tools/students.ts
@@ -14,23 +14,15 @@ export function registerStudentTools(server: McpServer, canvas: CanvasClient) {
     },
     { readOnlyHint: true },
     async ({ courseId, includeEmail, anonymous = true }: { courseId: string; includeEmail?: boolean; anonymous?: boolean }) => {
-      const students: any[] = [];
-      let page = 1;
-      let hasMore = true;
       try {
-        while (hasMore) {
-          const params: any = {
-            enrollment_type: ['student'],
-            per_page: 100,
-            page: page,
-            include: ['email', 'avatar_url'],
-            enrollment_state: ['active', 'invited']
-          };
-          const pageStudents = (await canvas.listStudents(courseId, params, { anonymous }) as any[]);
-          students.push(...pageStudents);
-          hasMore = pageStudents.length === 100;
-          page += 1;
-        }
+        // listStudents fetches every page internally; only request email when asked for.
+        const params: any = {
+          enrollment_type: ['student'],
+          per_page: 100,
+          include: includeEmail ? ['email', 'avatar_url'] : ['avatar_url'],
+          enrollment_state: ['active', 'invited']
+        };
+        const students = (await canvas.listStudents(courseId, params, { anonymous }) as any[]);
         const formattedStudents = students
           .map(student => {
             const parts = [

--- a/src/tools/submissions.ts
+++ b/src/tools/submissions.ts
@@ -181,7 +181,7 @@ export function registerSubmissionTools(server: McpServer, canvas: CanvasClient)
           content: [
             {
               type: "text",
-              text: JSON.stringify(response, null, 2)
+              text: JSON.stringify(response)
             }
           ]
         };
@@ -204,12 +204,23 @@ export function registerSubmissionTools(server: McpServer, canvas: CanvasClient)
     { readOnlyHint: true },
     async ({ fileId }: { fileId: string }) => {
       try {
-        const fileInfo = await canvas.getFileInfo(fileId);
+        const f = await canvas.getFileInfo(fileId) as any;
+        const summary = {
+          id: f.id,
+          filename: f.filename || f.display_name,
+          display_name: f.display_name,
+          content_type: f['content-type'] || f.content_type,
+          mime_class: f.mime_class,
+          size: f.size,
+          url: f.url,
+          created_at: f.created_at,
+          updated_at: f.updated_at,
+        };
         return {
           content: [
             {
               type: "text",
-              text: JSON.stringify(fileInfo, null, 2)
+              text: JSON.stringify(summary)
             }
           ]
         };
@@ -265,7 +276,7 @@ export function registerSubmissionTools(server: McpServer, canvas: CanvasClient)
           content: [
             {
               type: "text",
-              text: JSON.stringify(response, null, 2)
+              text: JSON.stringify(response)
             }
           ]
         };


### PR DESCRIPTION
## Overview

A round of correctness, efficiency, and privacy improvements to the Canvas MCP server, found while reviewing the implementation. No new tools or breaking schema removals — existing tool names and required params are unchanged.

## Bug fixes
- **Pagination infinite-loop** — `list-students` and `list-section-submissions` wrapped client methods that *already* fetch every page (`fetchAllPages`) in their own `while (length === 100)` loop. This duplicated rows and **never terminated** when the count was an exact multiple of 100. The redundant loops are removed.
- **Silent truncation** — `list-quizzes` and `list-quiz-questions` used an unpaginated `get`, so Canvas's default page size (10) silently dropped the rest. They now use `fetchAllPages({ per_page: 100 })`.

## Token usage
- Dropped `JSON.stringify(…, null, 2)` pretty-printing from the submission tools (pure overhead for a model consumer).
- `get-submission-file-info` returns a projected summary instead of the entire raw Canvas file object.
- **Styleguide injection is now opt-in.** `update-page-content` (`showStyleguidePreview`) and `patch-page-content` (`includeStyleguide`) default to off and emit a one-line "call `get-styleguide` if needed" pointer instead of inlining the ~5 KB styleguide HTML on every page edit. `update-page-content` also no longer risks writing an empty page when called with nothing to write.

## Caching & memory
- `fetchAllPages` now caches its assembled result for cacheable URLs (submissions stay uncached), so repeat roster/quiz/eportfolio listings don't re-download every page.
- `SimpleCache` gains a **500-entry LRU cap** (previously unbounded) and a **60s freshness window** so hot ETag'd reads (e.g. `list-courses`) can skip the revalidation round-trip.
- Write-invalidation no longer climbs to the course root, so creating one assignment stops wiping cached modules/pages/sections for the entire course. Item-level writes still refresh their containing collection list.

## Privacy
- `anonymizeUser` now strips `sis_user_id`, `login_id`, `avatar_url`, `integration_id`, and `pronouns` (plus `short_name`/`sortable_name`), closing the de-anonymization leak where `list-students` printed SIS ID and Avatar URL for an otherwise-anonymized "Student N". `list-students` only requests `email` when `includeEmail` is set. `id`/`user_id` are intentionally preserved so grading/commenting still work on anonymized listings.

## Reviewer notes
- The 60s freshness window means an **externally**-edited Canvas resource may not be reflected for up to a minute; writes through this server invalidate immediately, so it only affects out-of-band changes.
- Verified the cache freshness, LRU eviction, and invalidation-climb logic with a runtime check; `npm run build` passes.
- Deliberately **not** included (available as follow-ups): request timeouts + rate-limit retry, parallelizing independent fetches, and a `bulk-grade` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)